### PR TITLE
USB Mass Storage Improvements

### DIFF
--- a/USBMassStorage.cpp
+++ b/USBMassStorage.cpp
@@ -36,6 +36,7 @@ void USBMassStorage::setDriveData(uint32 driveNumber, uint32 numSectors, MassSto
 	usb_mass_drives[driveNumber].status = statuser;
 	usb_mass_drives[driveNumber].init = initializer;
 	usb_mass_drives[driveNumber].format = initializer;
+	usb_mass_update_max_lun(driveNumber);
 }
 
 void USBMassStorage::clearDrives() {

--- a/examples/mass/mass.ino
+++ b/examples/mass/mass.ino
@@ -54,6 +54,9 @@ void dumpDrive() {
 }
 
 void setup() {
+  /* Setting a serial number string is optional for a single drive, but
+   * is required for Windows to see multiple drives */
+  USBComposite.setSerialString()
   USBComposite.setProductId(PRODUCT_ID);
   MassStorage.setDriveData(0, sizeof(image)/SCSI_BLOCK_SIZE, read, write);
   MassStorage.registerComponent();

--- a/examples/sdreader/sdreader.ino
+++ b/examples/sdreader/sdreader.ino
@@ -34,6 +34,9 @@ void setup() {
 void initReader() {
   digitalWrite(LED_PIN,0);
   cardSize = sd.card()->cardSize();  
+  /* Setting a serial number string is optional for a single drive, but
+   * is required for Windows to see multiple drives */
+  USBComposite.setSerialString()
   MassStorage.setDriveData(0, cardSize, read, write);
   MassStorage.registerComponent();
   CompositeSerial.registerComponent();

--- a/usb_mass.c
+++ b/usb_mass.c
@@ -106,13 +106,13 @@ USBEndpointInfo usbMassEndpoints[2] = {
     {
         .callback = usb_mass_in,
         .pmaSize = MAX_BULK_PACKET_SIZE,
-        .type = USB_GENERIC_ENDPOINT_TYPE_BULK, 
+        .type = USB_GENERIC_ENDPOINT_TYPE_BULK,
         .tx = 1,
     },
     {
         .callback = usb_mass_out,
         .pmaSize = MAX_BULK_PACKET_SIZE,
-        .type = USB_GENERIC_ENDPOINT_TYPE_BULK, 
+        .type = USB_GENERIC_ENDPOINT_TYPE_BULK,
         .tx = 0,
     },
 };
@@ -331,7 +331,7 @@ static void usb_mass_bot_cbw_decode() {
           scsi_start_stop_unit_cmd(usb_mass_CBW.bLUN);
           break;
         case SCSI_ALLOW_MEDIUM_REMOVAL:
-          scsi_start_stop_unit_cmd(usb_mass_CBW.bLUN);
+          scsi_allow_medium_removal(usb_mass_CBW.bLUN);
           break;
         case SCSI_MODE_SENSE6:
           scsi_mode_sense6_cmd(usb_mass_CBW.bLUN);

--- a/usb_mass.c
+++ b/usb_mass.c
@@ -144,7 +144,10 @@ USBCompositePart usbMassPart = {
 };
 
 static void usb_mass_reset(void) {
-  usb_mass_mal_init(0);
+  uint32_t i;
+  for (i = 0; i < USB_MASS_MAX_DRIVES; i += 1) {
+    usb_mass_mal_init(i);
+  }
 
   pInformation->Current_Configuration = 0; // TODO: remove?
 
@@ -435,4 +438,10 @@ uint32_t usb_mass_sil_write(uint8_t* pBufferPointer, uint32_t wBufferSize) {
 
 uint32_t usb_mass_sil_read(uint8_t* pBufferPointer) {
     return usb_generic_read_to_buffer(USB_MASS_RX_ENDPOINT_INFO, pBufferPointer, USB_GENERIC_UNLIMITED_BUFFER);
+}
+
+void usb_mass_update_max_lun(uint32_t new_max_lun) {
+  if (new_max_lun > maxLun && new_max_lun < USB_MASS_MAX_DRIVES) {
+    maxLun = new_max_lun;
+  }
 }

--- a/usb_mass.h
+++ b/usb_mass.h
@@ -103,7 +103,9 @@ extern "C" {
   void usb_mass_bot_set_csw(uint8_t cswStatus, uint8_t sendPermission);
   void usb_mass_transfer_data_request(uint8_t* dataPointer, uint16_t dataLen);
   void usb_mass_bot_abort(uint8_t direction);
-  
+
+  void usb_mass_update_max_lun(uint32_t new_max_lun);
+
   extern USBCompositePart usbMassPart;
 
 extern uint8_t usb_mass_botState;

--- a/usb_mass_mal.h
+++ b/usb_mass_mal.h
@@ -13,6 +13,8 @@ extern "C" {
 //USB_MASS_MAX_DRIVES can be overridden using compiler flags if necessary (e.g. -D USB_MASS_MAX_DRIVES=4)
 #ifndef USB_MASS_MAX_DRIVES
 #define USB_MASS_MAX_DRIVES  2
+#elif USB_MASS_MAX_DRIVES > 16
+#error USB_MASS_MAX_DRIVES is limited to 16
 #endif
 
 typedef bool (*MassStorageWriter)(const uint8_t *writebuff, uint32_t startSector, uint16_t numSectors);

--- a/usb_mass_mal.h
+++ b/usb_mass_mal.h
@@ -8,9 +8,12 @@
 extern "C" {
 #endif
 
-#define SCSI_BLOCK_SIZE							     512
+#define SCSI_BLOCK_SIZE				512
 
+//USB_MASS_MAX_DRIVES can be overridden using compiler flags if necessary (e.g. -D USB_MASS_MAX_DRIVES=4)
+#ifndef USB_MASS_MAX_DRIVES
 #define USB_MASS_MAX_DRIVES  2
+#endif
 
 typedef bool (*MassStorageWriter)(const uint8_t *writebuff, uint32_t startSector, uint16_t numSectors);
 typedef bool (*MassStorageReader)(uint8_t *readbuff, uint32_t startSector, uint16_t numSectors);
@@ -19,7 +22,7 @@ typedef bool (*MassStorageInitializer)(void);
 typedef bool (*MassStorageFormatter)(void);
 
 typedef struct {
-    uint32_t blockCount;
+	uint32_t blockCount;
 	MassStorageReader read;
 	MassStorageWriter write;
 	MassStorageStatuser status;

--- a/usb_scsi.c
+++ b/usb_scsi.c
@@ -86,7 +86,7 @@ void scsi_allow_medium_removal(uint8_t lun) {
   (void)lun;
   //Return error for allow media removal comand.  This is necessary for proper eject behavior on
   //Mac OS, and may prevent write caching from being enabled on Windows, providing better performance
-  if (usb_mass_CBW.CB[4] & 0x03 == 0x00) { //PREVENT = false, succeeds
+  if ((usb_mass_CBW.CB[4] & 0x03) == 0x00) { //PREVENT = false, succeeds
     usb_mass_bot_set_csw(BOT_CSW_CMD_PASSED, BOT_SEND_CSW_ENABLE);
   } else { //PREVENT = true, fails
     //Stalling the endpoint here causes classic Mac OS to fail to mount the drive.

--- a/usb_scsi.h
+++ b/usb_scsi.h
@@ -75,6 +75,7 @@ extern "C" {
   void scsi_inquiry_cmd(uint8_t lun);
   void scsi_request_sense_cmd(uint8_t lun);
   void scsi_start_stop_unit_cmd(uint8_t lun);
+  void scsi_allow_medium_removal(uint8_t lun);
   void scsi_mode_sense6_cmd(uint8_t lun);
   void scsi_mode_sense10_cmd(uint8_t lun);
   void scsi_read_format_capacity_cmd(uint8_t lun);


### PR DESCRIPTION
This pull request addresses a few issues related to mass storage functionality.
* Allows more than one drive to be added.  Almost all the required support was already in place.  The maxLun variable was previously fixed at 0; it is now increased dynamically as new drives are added.  In some limited testing, some OSes seemed to get confused if drives were added that were not contiguous (e.g. If drives 0 and 2 but not 1 were configured).  I didn't look into this further, though.  I suspect this will not be a problem for most users.  Code which only sets up a single drive should also continue to work exactly as it did before.
* Because multiple drives are implemented using LUNs, up to 16 drives can be added without requiring any additional endpoint or buffer memory resources.  However, some additional memory will be required for the drive structures.  By default, only 2 drives are supported to save memory, but more can be added by overriding USB_MASS_MAX_DRIVES using a compiler flag.
* Windows (for unclear reasons) will not recognize USB mass storage devices with more than one LUN if the serial number string is not set.  It doesn't seem too picky about what it is, it just can't be missing.  I added notes to the two mass storage examples which clarify this point.
* The Mac OS uses the "allow medium removal" command to determine the type of drive, which affects eject behavior.  For correct behavior, the allow medium removal command needs to fail when a "prevent" request is sent, otherwise the drive will immediately be remounted when it is ejected.  This PR adds support for this command and returns the necessary values for eject functionality to work correctly.  Eject functionality also continues to work correctly on other platforms.